### PR TITLE
Fix `test_predict_from_test()` & `test_remove_user()`

### DIFF
--- a/src/features/api/test_api.py
+++ b/src/features/api/test_api.py
@@ -37,7 +37,7 @@ class TestAPI(unittest.TestCase):
 
     def test_predict_from_test(self):
         # Récupérer un utilisateur et son mot de passe à partir du fichier users_db.json
-        user, psw = "nouvel_utilisateur", "mot_de_passe"
+        user, psw = "fdo", "c0ps"
         # Envoi d'une requête GET à l'endpoint /predict_from_test avec l'en-tête d'identification
         response = client.get('/predict_from_test', headers={"identification": f"{user}:{psw}"})
         # Vérification que la réponse est OK (code 200)

--- a/src/features/api/test_api.py
+++ b/src/features/api/test_api.py
@@ -30,7 +30,7 @@ class TestAPI(unittest.TestCase):
     def test_remove_user(self):
         old_user_data = {"user": "test_user"}
         # Envoi d'une requête DELETE à l'endpoint /remove_user avec l'en-tête d'identification
-        response = client.delete(f'/remove_user?user={old_user_data["user"]}', headers={"identification": "admin:4dmin"})
+        response = client.request(method="DELETE", url='/remove_user', json=old_user_data, headers={"identification": "admin:4dmin"})
         # Vérification que la réponse est OK (code 200)
         self.assertTrue(response.status_code == 200, "Test remove_user: FAILED")
         print("Test remove_user: PASSED")


### PR DESCRIPTION
### `test_predict_from_test()`
Le correctif d'Alex résout bien le problème (ligne 40  `user, psw = "nouvel_utilisateur", "mot_de_passe"` changée en `user, psw = "fdo", "c0ps"`).

### `test_remove_user()`
Il y avait 2 sujets :

1. `old_user_data` est un payload. Dans la requête `curl`, il est passé non pas dans l’URL, mais sous le flag `-d` :
```
curl -X 'DELETE' \
  'http://127.0.0.1:8000/remove_user' \
  -H 'accept: application/json' \
  -H 'identification: admin:4dmin' \
  -H 'Content-Type: application/json' \
  -d '{
  "user": "policierB"
}'
```

2. Le souci, c’est que `TestClient.delete()` ne prend plus en charge les payloads depuis fin 2022 (https://github.com/tiangolo/fastapi/issues/5649). Le workaround recommandé est d’utiliser `TestClient.request(method="DELETE", url=..., ...)`.

Après avoir appliqué ces modifs chez moi, tous les voyants sont désormais au vert :
```
Test is_functional: PASSED
.Test predict_from_call: PASSED
.Test predict_from_test: PASSED
.Test register_user: PASSED
.Test remove_user: PASSED
.Test train_model: PASSED
.Test update_data: PASSED
.
```